### PR TITLE
Add generic interface tests

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -49,7 +49,7 @@ function MOI.optimize!(sampler::AbstractSampler, model::MOI.ModelLike)
 end
 
 function Base.show(io::IO, ::AbstractSampler)
-    Base.print(io, "An sampler for QUBO Models")
+    Base.print(io, "A sampler for QUBO Models")
 end
 
 # -*- :: -*- Constraint Support -*- :: -*-
@@ -115,7 +115,7 @@ function MOI.get(sampler::AbstractSampler, ::MOI.NumberOfThreads)
     return sampler.moi.number_of_threads
 end
 
-function MOI.set(sampler::AbstractSampler, ::MOI.NumberOfThreads, n::Int)
+function MOI.set(sampler::AbstractSampler, ::MOI.NumberOfThreads, n::Integer)
     sampler.moi.number_of_threads = n
 end
 
@@ -250,9 +250,9 @@ function MOI.get(sampler::AbstractSampler, ::MOI.VariablePrimalStart, vi::MOI.Va
     if !haskey(sampler.x, vi)
         throw(MOI.InvalidIndex{MOI.VariableIndex}(vi))
     elseif haskey(sampler.moi.variable_primal_start, vi)
-        return sampler.moi.variable_primal_start[vi]
+        sampler.moi.variable_primal_start[vi]
     else
-        return nothing
+        nothing
     end
 end
 
@@ -271,25 +271,25 @@ end
 MOI.supports(::AbstractSampler, ::MOI.VariablePrimalStart, ::Type{<:MOI.VariableIndex}) = true
 
 function MOI.get(::AbstractSampler, ::MOI.VariableName, v::VI)
-    return "v[$(v.value)]"
+    "v[$(v.value)]"
 end
 
 function MOI.get(::AbstractSampler, ::MOI.ListOfConstraintTypesPresent)
-    return [(VI, MOI.ZeroOne)]
+    [(VI, MOI.ZeroOne)]
 end
 
 function MOI.get(sampler::AbstractSampler, ::MOI.ListOfConstraintIndices{VI, MOI.ZeroOne})
-    return CI{VI, MOI.ZeroOne}[CI{VI, MOI.ZeroOne}(xᵢ.value) for xᵢ ∈ MOI.get(sampler, MOI.ListOfVariableIndices())]
+    CI{VI, MOI.ZeroOne}[CI{VI, MOI.ZeroOne}(xᵢ.value) for xᵢ ∈ MOI.get(sampler, MOI.ListOfVariableIndices())]
 end
 
 function MOI.get(sampler::AbstractSampler, ::MOI.ListOfVariableIndices)
-    return VI[xᵢ for xᵢ ∈ keys(sampler.x)]
+    VI[xᵢ for xᵢ ∈ keys(sampler.x)]
 end
 
 function MOI.get(::AbstractSampler, ::MOI.ConstraintFunction, i::CI{VI, MOI.ZeroOne})
-    return VI(i.value)
+    VI(i.value)
 end
 
 function MOI.get(::AbstractSampler, ::MOI.ConstraintSet, i::CI{VI, MOI.ZeroOne})
-    return MOI.ZeroOne()
+    MOI.ZeroOne()
 end

--- a/test/error.jl
+++ b/test/error.jl
@@ -1,7 +1,6 @@
 @testset "Error Messages" begin
     io = IOBuffer()
 
-
     error_msg = "Error Message!"
 
     showerror(io, Anneal.AnnealingError(error_msg))

--- a/test/interface/anneal.jl
+++ b/test/interface/anneal.jl
@@ -1,0 +1,7 @@
+function test_anneal(Optimizer::Type{<:AbstractSampler})
+    @test hasmethod(MOI.get, (Optimizer, MOI.SolverName))
+    @test hasmethod(MOI.get, (Optimizer, MOI.SolverVersion)) 
+    @test hasmethod(MOI.get, (Optimizer, MOI.RawSolver))
+
+    @test hasmethod(Anneal.sample, (Optimizer,))
+end

--- a/test/interface/jump.jl
+++ b/test/interface/jump.jl
@@ -1,0 +1,3 @@
+function test_jump(Optimizer::Type{<:AbstractSampler})
+    
+end

--- a/test/interface/moi.jl
+++ b/test/interface/moi.jl
@@ -1,0 +1,3 @@
+function test_moi(Optimizer::Type{<:AbstractSampler})
+    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,10 +11,14 @@ include("error.jl")
 include("tools.jl")
 include("samples.jl")
 
-# -*- Samplers -*-
+include("interface/moi.jl")
+include("interface/jump.jl")
+include("interface/anneal.jl")
+
+# -*- Utility Samplers -*-
 include("samplers/exact.jl")
 include("samplers/identity.jl")
 include("samplers/random.jl")
 
-# -*- Annealers -*-
-include("annealers/simulated.jl")
+# -*- Bundled Samplers -*-
+include("samplers/simulated.jl")

--- a/test/samplers/exact.jl
+++ b/test/samplers/exact.jl
@@ -1,4 +1,8 @@
 @testset "Exact Sampling" begin
+    @testset "Interface Check" begin
+        test_anneal(ExactSampler.Optimizer)
+    end
+
     @testset "MOI Attributes" begin
         sampler = ExactSampler.Optimizer{Float64}()
 

--- a/test/samplers/identity.jl
+++ b/test/samplers/identity.jl
@@ -1,4 +1,8 @@
 @testset "Identity Sampling" begin
+    @testset "Interface Check" begin
+        test_anneal(IdentitySampler.Optimizer)
+    end
+    
     @testset "MOI Attributes" begin
         sampler = IdentitySampler.Optimizer{Float64}()
 

--- a/test/samplers/random.jl
+++ b/test/samplers/random.jl
@@ -1,4 +1,8 @@
 @testset "Random Sampling" begin
+    @testset "Interface Check" begin
+        test_anneal(RandomSampler.Optimizer)
+    end
+
     @testset "MOI Attributes" begin
         sampler = RandomSampler.Optimizer{Float64}()
 

--- a/test/samplers/simulated.jl
+++ b/test/samplers/simulated.jl
@@ -1,4 +1,8 @@
 @testset "Simulated Annealing" begin
+    @testset "Interface Check" begin
+        test_anneal(SimulatedAnnealer.Optimizer)
+    end
+
     @testset "MOI Attributes" begin
         annealer = SimulatedAnnealer.Optimizer{Float64}()
 


### PR DESCRIPTION
This PR aims to enhance coverage over MOI interface defined for `AbstractSampler <: AbstractOptimizer` and also sketch a pair of procedures to `Anneal.test(::Type{AbstractSampler})` and `Anneal.benchmark(::Type{AbstractSampler})` sampler interfaces.